### PR TITLE
making compatible with v1.5.3 and above pwnagotchi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Dropbox api plugin for pwnagotchi.
 Compatible with v1.5.3 and above which uses toml for configuration instead of yml 
 
-# dropbox_ul steps
-Create an app for dropbox @ https://www.dropbox.com/developers/apps/create
+# dropbox app console steps
+Create an app for dropbox @ https://www.dropbox.com/developers/apps/create.
 generate and copy app token from your app console.
 copy the path/folder name.
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,16 @@
-# pwnplugins
-plugins for pwnagotchi
+Dropbox api plugin for pwnagotchi.
+Compatible with v1.5.3 and above which uses toml for configuration instead of yml 
 
-# dropbox_ul 
+# dropbox_ul steps
 Create an app for dropbox @ https://www.dropbox.com/developers/apps/create
+generate and copy app token from your app console.
+copy the path/folder name.
 
-* Dropbox api
-* App folder
-* Whatever name you line
+# Steps to make this plugins work on pwnagotchi 1.5.3. and above using toml config
+copy dropbox_ul.py to /home/pi/pwnplugins
+edit main config.toml with
 
-Generate a token, replacing \<db app token> with yours. 
-
-    dropbox_ul:
-	    enabled: true
-	    app_token: '<db app token>'
-	    path: '/dropbox-ul'
-
-And enjoy, new handshakes will automagically turn up in your Dropbox/Apps folder when the pwnagotchi is online. 
+main.custom_plugins = "/home/pi/pwnplugins"
+main.plugins.dropbox_ul.enabled = true
+main.plugins.dropbox_ul.app_token = "token generated in app console"
+main.plugins.dropbox_ul.path = "/path or folder name made in app console"

--- a/README.md
+++ b/README.md
@@ -3,14 +3,20 @@ Compatible with v1.5.3 and above which uses toml for configuration instead of ym
 
 # dropbox app console steps
 Create an app for dropbox @ https://www.dropbox.com/developers/apps/create.
+
 generate and copy app token from your app console.
+
 copy the path/folder name.
 
 # Steps to make this plugins work on pwnagotchi 1.5.3. and above using toml config
 copy dropbox_ul.py to /home/pi/pwnplugins
+
 edit main config.toml with
 
 main.custom_plugins = "/home/pi/pwnplugins"
+
 main.plugins.dropbox_ul.enabled = true
+
 main.plugins.dropbox_ul.app_token = "token generated in app console"
+
 main.plugins.dropbox_ul.path = "/path or folder name made in app console"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ copy the path/folder name.
 # Steps to make this plugins work on pwnagotchi 1.5.3. and above using toml config
 copy dropbox_ul.py to /home/pi/pwnplugins
 
-edit main config.toml with
+edit main config.toml in pwnagotchi device with
 
 main.custom_plugins = "/home/pi/pwnplugins"
 

--- a/dropbox_ul.yml
+++ b/dropbox_ul.yml
@@ -1,4 +1,0 @@
-dropbox_ul:
-    enabled: true
-    app_token: 'db app token'
-    path: '/dropbox-ul'


### PR DESCRIPTION
these edits are necessary for Dropbox upload API plugin to work in the current v1.5.3 and above which used toml configuration. 
Changes made:
deleted dropbox_ul.yml. toml config is done directly in main config.toml
edited readme to reflect new steps.